### PR TITLE
Port fix for pip from microk8s

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -118,7 +118,7 @@ parts:
     source-type: git
     plugin: autotools
     configflags:
-      - --enable-debug  
+      - --enable-debug
     stage-packages:
       - libuv1
     organize:
@@ -162,7 +162,7 @@ parts:
     source-type: git
     plugin: autotools
     configflags:
-      - --enable-debug       
+      - --enable-debug
     stage-packages:
       - libuv1
     build-packages:
@@ -377,6 +377,10 @@ parts:
     - gunicorn3
     - python3-click
     - python3-dateutil
+    override-pull: |
+      apt-get install -y python3-pip
+      PYTHONHOME=/usr PYTHONUSERBASE=$SNAPCRAFT_PART_INSTALL $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install --upgrade 'pip; python_version >= "3.6"' 'pip<21; python_version < "3.6"' --user
+      snapcraftctl pull
 
   microk8s:
     after: [containerd, dqlite, k8s-binaries]


### PR DESCRIPTION
See: https://github.com/ubuntu/microk8s/pull/1937

Original author's (@joedborg) commit message:

    Hotfix for the latest release of PIP. The latest release breaks the snap as it uses f{} formatting, which isn't supported by Python 3.5, which is what comes with core16.
    Mid term fix is to bundle our own Python build, replacing the old version that comes with core16.
    Longest term fix is to move to core20.